### PR TITLE
Print newline character after errors, minor cleanup & docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # go-camera
-Interface with the raspberry pi camera module with golang
+Interface with the Raspberry Pi camera module with Golang.
+
+## Example Code
+
+    import "github.com/loranbriggs/go-camera"
+
+    c := camera.New(folder)
+    s, err := t.Camera.Capture()
+

--- a/camera.go
+++ b/camera.go
@@ -1,65 +1,63 @@
 package camera
 
 import (
-  "fmt"
-  "os/exec"
-  "path/filepath"
-  "time"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"time"
 )
 
 const (
-  STILL = "raspistill"
-  HFLIP = "-hf"
-  VFLIP = "-vf"
-  OUTFLAG = "-o"
-  FILE_TYPE =".jpg"
-  TIME_STAMP = "2006-01-02_15:04::05"
+	STILL      = "raspistill"
+	HFLIP      = "-hf"
+	VFLIP      = "-vf"
+	OUTFLAG    = "-o"
+	FILE_TYPE  = ".jpg"
+	TIME_STAMP = "2006-01-02_15:04::05"
 )
 
 type Camera struct {
-  horizontalFlip bool
-  verticalFlip bool
-  savePath string
+	horizontalFlip bool
+	verticalFlip   bool
+	savePath       string
 }
 
 func New(path string) *Camera {
-  if path =="" {
-    return nil
-  }
-  return &Camera{false, false, path}
+	if path == "" {
+		return nil
+	}
+	return &Camera{false, false, path}
 }
 
 func (c *Camera) Hflip(b bool) {
-  c.horizontalFlip = b
+	c.horizontalFlip = b
 }
 
 func (c *Camera) Vflip(b bool) {
-  c.verticalFlip = b
+	c.verticalFlip = b
 }
 
 func (c *Camera) Capture() (string, error) {
-  args := make([]string, 0)
-  if c.horizontalFlip {
-    args = append(args, HFLIP)
-  }
-  if c.verticalFlip {
-    args = append(args, VFLIP)
-  }
-  args = append(args, OUTFLAG)
-  fileName := time.Now().Format(TIME_STAMP) + FILE_TYPE
-  fullPath := filepath.Join(c.savePath, fileName)
-  args = append(args, fullPath)
-  cmd := exec.Command("raspistill", "-o", fullPath)
-  _, err := cmd.StdoutPipe()
-  if err != nil {
-    fmt.Println(err)
-  }
-  err = cmd.Start()
-  if err != nil {
-    fmt.Println(err)
-  }
-  cmd.Wait()
-  return fullPath, nil
+	args := make([]string, 0)
+	if c.horizontalFlip {
+		args = append(args, HFLIP)
+	}
+	if c.verticalFlip {
+		args = append(args, VFLIP)
+	}
+	args = append(args, OUTFLAG)
+	fileName := time.Now().Format(TIME_STAMP) + FILE_TYPE
+	fullPath := filepath.Join(c.savePath, fileName)
+	args = append(args, fullPath)
+	cmd := exec.Command("raspistill", "-o", fullPath)
+	_, err := cmd.StdoutPipe()
+	if err != nil {
+		fmt.Println(err)
+	}
+	err = cmd.Start()
+	if err != nil {
+		fmt.Println(err)
+	}
+	cmd.Wait()
+	return fullPath, nil
 }
-
-

--- a/camera.go
+++ b/camera.go
@@ -52,11 +52,11 @@ func (c *Camera) Capture() (string, error) {
   cmd := exec.Command("raspistill", "-o", fullPath)
   _, err := cmd.StdoutPipe()
   if err != nil {
-    fmt.Print(err)
+    fmt.Println(err)
   }
   err = cmd.Start()
   if err != nil {
-    fmt.Print(err)
+    fmt.Println(err)
   }
   cmd.Wait()
   return fullPath, nil

--- a/camera.go
+++ b/camera.go
@@ -49,7 +49,7 @@ func (c *Camera) Capture() (string, error) {
 	fileName := time.Now().Format(TIME_STAMP) + FILE_TYPE
 	fullPath := filepath.Join(c.savePath, fileName)
 	args = append(args, fullPath)
-	cmd := exec.Command("raspistill", "-o", fullPath)
+	cmd := exec.Command(STILL, OUTFLAG, fullPath)
 	_, err := cmd.StdoutPipe()
 	if err != nil {
 		fmt.Println(err)


### PR DESCRIPTION
I changed the `fmt.Print` into a `fmt.Println` when printing errors, did some cleanup (via `go fmt`), and added a basic example to the `README.md`